### PR TITLE
Add -b flag to fork switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+Release 0.1.5 (2020-07-22)
+=====
+* Make the username argument under `emu fork switch` optional. If not specified, it will use the current fork switched to
+* Add `--branch` (`-b`) flag for specifying the branch
+  * This means you must supply `-b` or `--branch` when switching branches, even when supplying the username:
+
+        Old syntax: emu fork switch same_fork new_branch
+        New syntax: emu fork switch -b new_branch
+
+Release 0.1.4 (2020-07-12)
+=====
+* Add `emu device settings` command to open the settings app
+
 Release 0.1.3 (2020-07-06)
 =====
 * Make flags/arguments more robust. Optional non-positional arguments are now supported, as long as they are the last arguments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Release 0.1.5 (2020-07-22)
 * Add `--branch` (`-b`) flag for specifying the branch
   * This means you must supply `-b` or `--branch` when switching branches, even when supplying the username:
 
+        Old syntax: emu fork switch another_fork branch
+        New syntax: emu fork switch another_fork -b branch
+
         Old syntax: emu fork switch same_fork new_branch
         New syntax: emu fork switch -b new_branch
 

--- a/commands/README.md
+++ b/commands/README.md
@@ -6,6 +6,7 @@
   - Arguments 💢:
     - username: 👤 The username of the fork's owner to install
     - branch (optional): 🌿 Branch to switch to, will use default branch if not provided
+    - *New Behavior*: If a branch is provided with -b and username is missing, it will assume the current fork
   - Example 📚:
     - `emu fork switch stock devel`
 - `emu fork list`: 📜 See a list of installed forks and branches

--- a/commands/README.md
+++ b/commands/README.md
@@ -4,9 +4,9 @@
 🍴 Manage installed forks, or install a new one
 - `emu fork switch`: 🍴 Switch between any openpilot fork
   - Arguments 💢:
-    - username: 👤 The username of the fork's owner to install
-    - branch (optional): 🌿 Branch to switch to, will use default branch if not provided
-    - *New Behavior*: If a branch is provided with -b and username is missing, it will assume the current fork
+    - username (optional): 👤 The username of the fork's owner to switch to, will use current fork if not provided
+    - -b, --branch (optional): 🌿 Branch to switch to, will use fork's default branch if not provided
+    - *New Behavior:* If a branch is provided with `-b` and username is not supplied, it will use the current fork switched to
   - Example 📚:
     - `emu fork switch stock devel`
 - `emu fork list`: 📜 See a list of installed forks and branches

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 import os
 import importlib
 from py_utils.emu_utils import error

--- a/commands/base.py
+++ b/commands/base.py
@@ -49,6 +49,8 @@ class CommandBase(BaseFunctions):
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
         usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
+        print(usage_flags)
+        print(usage_non_req)
         # usage_flags = '[{}]'.format(', '.join(usage_flags))
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags

--- a/commands/base.py
+++ b/commands/base.py
@@ -48,7 +48,9 @@ class CommandBase(BaseFunctions):
       if len(usage_req) > 0 or len(usage_non_req) > 0:  # print usage with proper braces
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
-        usage_flags = ['[{}]'.format(u) for u in usage_flags]
+        usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
+        # usage_flags = '[{}]'.format(', '.join(usage_flags))
+
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags
         print(leading + COLORS.WARNING + '>>  Usage:{} {}'.format(COLORS.OKGREEN, ' '.join(usage)) + COLORS.ENDC)
 

--- a/commands/base.py
+++ b/commands/base.py
@@ -49,7 +49,8 @@ class CommandBase(BaseFunctions):
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
         usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
-        usage_flags = ['[{}]'.format(', '.join(usage_flags))]
+        # usage_flags = ['[{}]'.format(', '.join(usage_flags))]
+        usage_flags = [str(usage_flags)]
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags
         print(leading + COLORS.WARNING + '>>  Usage:{} {}'.format(COLORS.OKGREEN, ' '.join(usage)) + COLORS.ENDC)

--- a/commands/base.py
+++ b/commands/base.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 from py_utils.colors import COLORS
 from py_utils.emu_utils import ArgumentParser, BaseFunctions, success, error
 

--- a/commands/base.py
+++ b/commands/base.py
@@ -44,7 +44,7 @@ class CommandBase(BaseFunctions):
     if flags is not None and len(flags) > 0:
       usage_req = [f.aliases[0] for f in flags if f.required and len(f.aliases) == 1]  # if required
       usage_non_req = [f.aliases[0] for f in flags if not f.required and len(f.aliases) == 1]  # if non-required non-positional
-      usage_flags = [f.aliases[0] for f in flags if not f.required and len(f.aliases) > 1 or f.aliases[0].startswith('-')]  # if flag
+      usage_flags = [f.aliases for f in flags if not f.required and len(f.aliases) > 1 or f.aliases[0].startswith('-')]  # if flag
       if len(usage_req) > 0 or len(usage_non_req) > 0:  # print usage with proper braces
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]

--- a/commands/base.py
+++ b/commands/base.py
@@ -49,7 +49,7 @@ class CommandBase(BaseFunctions):
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
         usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
-        usage_flags = '[{}]'.format(', '.join(usage_flags))
+        usage_flags = ['[{}]'.format(', '.join(usage_flags))]
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags
         print(leading + COLORS.WARNING + '>>  Usage:{} {}'.format(COLORS.OKGREEN, ' '.join(usage)) + COLORS.ENDC)

--- a/commands/base.py
+++ b/commands/base.py
@@ -50,7 +50,7 @@ class CommandBase(BaseFunctions):
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
         usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
         print(usage_flags)
-        print(usage_non_req)
+        print(usage_req)
         # usage_flags = '[{}]'.format(', '.join(usage_flags))
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags

--- a/commands/base.py
+++ b/commands/base.py
@@ -49,7 +49,8 @@ class CommandBase(BaseFunctions):
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
         if len(usage_flags):
-          usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
+          # formats flags to: "[-b BRANCH, -o OUTPUT]"
+          usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]
           usage_flags = ['[{}]'.format(', '.join(usage_flags))]
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags

--- a/commands/base.py
+++ b/commands/base.py
@@ -48,9 +48,10 @@ class CommandBase(BaseFunctions):
       if len(usage_req) > 0 or len(usage_non_req) > 0:  # print usage with proper braces
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
-        usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
-        # usage_flags = ['[{}]'.format(', '.join(usage_flags))]
-        usage_flags = [str(usage_flags)]
+        if len(usage_flags):
+          usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
+          # usage_flags = ['[{}]'.format(', '.join(usage_flags))]
+          usage_flags = [str(usage_flags)]
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags
         print(leading + COLORS.WARNING + '>>  Usage:{} {}'.format(COLORS.OKGREEN, ' '.join(usage)) + COLORS.ENDC)

--- a/commands/base.py
+++ b/commands/base.py
@@ -44,10 +44,12 @@ class CommandBase(BaseFunctions):
     if flags is not None and len(flags) > 0:
       usage_req = [f.aliases[0] for f in flags if f.required and len(f.aliases) == 1]  # if required
       usage_non_req = [f.aliases[0] for f in flags if not f.required and len(f.aliases) == 1]  # if non-required non-positional
+      usage_flags = [f.aliases[0] for f in flags if not f.required and len(f.aliases) > 1 or f.aliases[0].startswith('-')]  # if flag
       if len(usage_req) > 0 or len(usage_non_req) > 0:  # print usage with proper braces
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
-        usage = ['emu', self.name, cmd] + usage_req + usage_non_req
+        usage_flags = ['[{}]'.format(u) for u in usage_flags]
+        usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags
         print(leading + COLORS.WARNING + '>>  Usage:{} {}'.format(COLORS.OKGREEN, ' '.join(usage)) + COLORS.ENDC)
 
       print(leading + COLORS.WARNING + '>>  Arguments 💢:' + COLORS.ENDC)

--- a/commands/base.py
+++ b/commands/base.py
@@ -50,8 +50,7 @@ class CommandBase(BaseFunctions):
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
         if len(usage_flags):
           usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
-          # usage_flags = ['[{}]'.format(', '.join(usage_flags))]
-          usage_flags = [str(usage_flags)]
+          usage_flags = ['[{}]'.format(', '.join(usage_flags))]
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags
         print(leading + COLORS.WARNING + '>>  Usage:{} {}'.format(COLORS.OKGREEN, ' '.join(usage)) + COLORS.ENDC)

--- a/commands/base.py
+++ b/commands/base.py
@@ -49,9 +49,7 @@ class CommandBase(BaseFunctions):
         usage_req = ['[{}]'.format(u) for u in usage_req]
         usage_non_req = ['({})'.format(u) for u in usage_non_req]
         usage_flags = ['{} {}'.format(min(u, key=len), max(u, key=len).upper()[2:]) for u in usage_flags]  # formats to: ['-b BRANCH', '-o OUTPUT']
-        print(usage_flags)
-        print(usage_req)
-        # usage_flags = '[{}]'.format(', '.join(usage_flags))
+        usage_flags = '[{}]'.format(', '.join(usage_flags))
 
         usage = ['emu', self.name, cmd] + usage_req + usage_non_req + usage_flags
         print(leading + COLORS.WARNING + '>>  Usage:{} {}'.format(COLORS.OKGREEN, ' '.join(usage)) + COLORS.ENDC)

--- a/commands/debug/__init__.py
+++ b/commands/debug/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 from commands.base import CommandBase, Command, Flag
 from py_utils.emu_utils import run, kill, warning, error
 from py_utils.emu_utils import OPENPILOT_PATH

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 from commands.base import CommandBase, Command, Flag
 from py_utils.emu_utils import run, warning, error, check_output, COLORS, success
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -143,8 +143,14 @@ class Fork(CommandBase):
         self._help('switch')
         return
 
-    print(flags.username)
-    print(flags.branch)
+    if flags.username is None:  # branch is specified, so use current checked out fork/username
+      _current_fork = self.fork_params.get('current_fork')
+      if _current_fork is not None:  # ...if available
+        success('No username specified, using current fork: {}'.format(_current_fork))
+        flags.username = _current_fork
+      else:
+        error('Current fork is unknown, please switch to a fork first before switching between branches!')
+        return
 
     username = flags.username.lower()
     if username in self.stock_aliases:
@@ -193,7 +199,7 @@ class Fork(CommandBase):
       error('Error: Cannot find default branch from fork!')
       return
 
-    if flags.branch is None:  # user hasn't specified a branch, use remote's branch
+    if flags.branch is None:  # user hasn't specified a branch, use remote's default branch
       if username == COMMA_ORIGIN_NAME:  # todo: use a dict for default branches if we end up needing default branches for multiple forks
         branch = COMMA_DEFAULT_BRANCH  # use release2 and default branch for stock
         fork_branch = 'commaai_{}'.format(branch)

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -73,7 +73,7 @@ class Fork(CommandBase):
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
                                        flags=[Flag('username', '👤 The username of the fork\'s owner to install', required=True, dtype='str'),
                                               Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str'),
-                                              Flag(['-o', '--output'], 'Random flag...', required=False, dtype='str')]),
+                                              Flag(['--output', '-o'], 'Random flag...', required=False, dtype='str')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -71,7 +71,7 @@ class Fork(CommandBase):
     self.stock_aliases = ['stock', COMMA_ORIGIN_NAME, 'origin']
 
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
-                                       flags=[Flag('username', '👤 The username of the fork\'s owner to install', required=False, dtype='str'),
+                                       flags=[Flag('username', '👤 The username of the fork\'s owner to switch to, will use current fork if not provided', required=False, dtype='str'),
                                               Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -138,15 +138,10 @@ class Fork(CommandBase):
       self._help('switch')
       return
     else:  # since both are non-required we need custom logic to check user supplied sufficient args/flags
-      if [flags.username, flags.branch] is [None, None]:
-        print(1)
-        error('You must supply either username or branch or both!')
-      if [flags.username, flags.branch] == [None, None]:
-        print(2)
-        error('You must supply either username or branch or both!')
       if flags.username is flags.branch is None:
-        print(3)
         error('You must supply either username or branch or both!')
+        self._help('switch')
+        return
 
     print(flags.username)
     print(flags.branch)

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -72,7 +72,7 @@ class Fork(CommandBase):
 
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
                                        flags=[Flag('username', '👤 The username of the fork\'s owner to install', required=True, dtype='str'),
-                                              Flag(['-b', '--branch', 'branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str')]),
+                                              Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -71,9 +71,8 @@ class Fork(CommandBase):
     self.stock_aliases = ['stock', COMMA_ORIGIN_NAME, 'origin']
 
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
-                                       flags=[Flag('username', '👤 The username of the fork\'s owner to install', required=True, dtype='str'),
-                                              Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str'),
-                                              Flag(['--output', '-o'], 'Random flag...', required=False, dtype='str')]),
+                                       flags=[Flag('username', '👤 The username of the fork\'s owner to install', required=False, dtype='str'),
+                                              Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 import shutil
 import os
 import json

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -134,12 +134,12 @@ class Fork(CommandBase):
     if not self._init():
       return
     flags, e = self.parse_flags(self.commands['switch'].parser)
-    print(flags.username)
-    print(flags.branch)
     if e is not None:
       error(e)
       self._help('switch')
       return
+    print(flags.username)
+    print(flags.branch)
 
     username = flags.username.lower()
     if username in self.stock_aliases:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -137,6 +137,17 @@ class Fork(CommandBase):
       error(e)
       self._help('switch')
       return
+    else:  # since both are non-required we need custom logic to check user supplied sufficient args/flags
+      if [flags.username, flags.branch] is [None, None]:
+        print(1)
+        error('You must supply either username or branch or both!')
+      if [flags.username, flags.branch] == [None, None]:
+        print(2)
+        error('You must supply either username or branch or both!')
+      if flags.username is flags.branch is None:
+        print(3)
+        error('You must supply either username or branch or both!')
+
     print(flags.username)
     print(flags.branch)
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -72,7 +72,7 @@ class Fork(CommandBase):
 
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
                                        flags=[Flag('username', '👤 The username of the fork\'s owner to install', required=True, dtype='str'),
-                                              Flag('branch', '🌿 Branch to switch to, will use default branch if not provided', dtype='str')]),
+                                              Flag(['-b', '--branch', 'branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 
@@ -133,6 +133,8 @@ class Fork(CommandBase):
     if not self._init():
       return
     flags, e = self.parse_flags(self.commands['switch'].parser)
+    print(flags.username)
+    print(flags.branch)
     if e is not None:
       error(e)
       self._help('switch')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -72,7 +72,8 @@ class Fork(CommandBase):
 
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
                                        flags=[Flag('username', '👤 The username of the fork\'s owner to install', required=True, dtype='str'),
-                                              Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str')]),
+                                              Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str'),
+                                              Flag(['-o', '--output'], 'Random flag...', required=False, dtype='str')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -146,7 +146,7 @@ class Fork(CommandBase):
     if flags.username is None:  # branch is specified, so use current checked out fork/username
       _current_fork = self.fork_params.get('current_fork')
       if _current_fork is not None:  # ...if available
-        success('No username specified, using current fork: {}'.format(_current_fork))
+        info('No username specified, using current fork: {}'.format(_current_fork))
         flags.username = _current_fork
       else:
         error('Current fork is unknown, please switch to a fork first before switching between branches!')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -146,7 +146,7 @@ class Fork(CommandBase):
     if flags.username is None:  # branch is specified, so use current checked out fork/username
       _current_fork = self.fork_params.get('current_fork')
       if _current_fork is not None:  # ...if available
-        info('No username specified, using current fork: {}'.format(_current_fork))
+        info('No username specified, using current fork: {}'.format(COLORS.SUCCESS + _current_fork + COLORS.ENDC))
         flags.username = _current_fork
       else:
         error('Current fork is unknown, please switch to a fork first before switching between branches!')

--- a/commands/panda/__init__.py
+++ b/commands/panda/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 import importlib
 from commands.base import CommandBase, Command
 from py_utils.emu_utils import run, error

--- a/commands/uninstall/__init__.py
+++ b/commands/uninstall/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 from commands.base import CommandBase, Command, Flag
 from py_utils.emu_utils import run, warning, error, check_output, COLORS, success, input_with_options, UNINSTALL_PATH
 

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ COMMUNITY_BASHRC_PATH=/data/community/.bashrc
 OH_MY_COMMA_PATH=/data/community/.oh-my-comma
 GIT_BRANCH_NAME=master
 GIT_REMOTE_URL=https://github.com/emu-sh/.oh-my-comma.git
-OMC_VERSION=0.1.4
+OMC_VERSION=0.1.5
 
 update=false
 if [ $# -ge 1 ] && [ $1 = "update" ]; then


### PR DESCRIPTION
Previous behavior was to always require username and branch would be assumed to be default if not specified.

New behavior allows user to type `emu fork switch -b cool_branch_name`. The username is assumed to the current fork the user has switched to last. If the user wants to switch to another fork and branch, then the only difference is they have to type `emu fork switch another_fork_user -b another_branch` (add `-b` in front of branch).

The new print to let the user know what's happening when only branch is specified:
```
root@localhost:/data/$ emu fork switch -b stock_additions-075
No username specified, using current fork: shanesmiskol
Fetching shanesmiskol's latest changes...
Successfully checked out shanesmiskol/stock_additions-075 as shanesmiskol_stock_additions-075
```

I need to test what happens right after the user sets up fork management, so don't merge yet. I'll also bump the version and update the changelog soon.

Edit:
- [x] bumped version and updated docs and changelog.
- [ ] just need to test what happens right after setting up fork management