### PR TITLE
Run user's switch command after fork setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Release 0.1.8 (2020-07-29)
+=====
+
+* More verbose fork switching, shows git output
+* Only print newline when more information about command is available to better differentiate between commands
+
 Release 0.1.7 (2020-07-24)
 =====
 

--- a/commands/base.py
+++ b/commands/base.py
@@ -70,8 +70,8 @@ class CommandBase(BaseFunctions):
 
     commands = self.commands[cmd].commands
     cmds_to_print = []
+    print('here?')
     if commands is not None and len(commands) > 0:
-      print('here?')
       print(leading + '{}>>  Commands 💻:{}'.format(COLORS.OKGREEN, COLORS.ENDC))
       for cmd in commands:
         cmds_to_print.append(leading + COLORS.FAIL + '  - {}: {}'.format(cmd, success(commands[cmd].description, ret=True)) + COLORS.ENDC)

--- a/commands/base.py
+++ b/commands/base.py
@@ -71,6 +71,7 @@ class CommandBase(BaseFunctions):
     commands = self.commands[cmd].commands
     cmds_to_print = []
     if commands is not None and len(commands) > 0:
+      print('here?')
       print(leading + '{}>>  Commands 💻:{}'.format(COLORS.OKGREEN, COLORS.ENDC))
       for cmd in commands:
         cmds_to_print.append(leading + COLORS.FAIL + '  - {}: {}'.format(cmd, success(commands[cmd].description, ret=True)) + COLORS.ENDC)

--- a/commands/base.py
+++ b/commands/base.py
@@ -36,6 +36,7 @@ class CommandBase(BaseFunctions):
       return None, e
 
   def _help(self, cmd, show_description=True, leading=''):
+    has_extra_info = False
     description = self.commands[cmd].description
     if show_description:
       print('{}>>  Description 📚: {}{}'.format(COLORS.CYAN, description, COLORS.ENDC))
@@ -44,6 +45,7 @@ class CommandBase(BaseFunctions):
 
     flags_to_print = []
     if flags is not None and len(flags) > 0:
+      has_extra_info = True
       usage_req = [f.aliases[0] for f in flags if f.required and len(f.aliases) == 1]  # if required
       usage_non_req = [f.aliases[0] for f in flags if not f.required and len(f.aliases) == 1]  # if non-required non-positional
       usage_flags = [f.aliases for f in flags if not f.required and len(f.aliases) > 1 or f.aliases[0].startswith('-')]  # if flag
@@ -73,6 +75,7 @@ class CommandBase(BaseFunctions):
       for cmd in commands:
         cmds_to_print.append(leading + COLORS.FAIL + '  - {}: {}'.format(cmd, success(commands[cmd].description, ret=True)) + COLORS.ENDC)
       print('\n'.join(cmds_to_print))
+    return has_extra_info
 
 class Flag:
   def __init__(self, aliases, description, required=False, dtype='bool'):

--- a/commands/base.py
+++ b/commands/base.py
@@ -36,7 +36,6 @@ class CommandBase(BaseFunctions):
       return None, e
 
   def _help(self, cmd, show_description=True, leading=''):
-    print('here?')
     has_extra_info = False
     description = self.commands[cmd].description
     if show_description:
@@ -45,7 +44,6 @@ class CommandBase(BaseFunctions):
     flags = self.commands[cmd].flags
 
     flags_to_print = []
-    print('here?')
     if flags is not None and len(flags) > 0:
       has_extra_info = True
       usage_req = [f.aliases[0] for f in flags if f.required and len(f.aliases) == 1]  # if required
@@ -69,7 +67,6 @@ class CommandBase(BaseFunctions):
           aliases += COLORS.RED + ' (optional)' + COLORS.WARNING
         flags_to_print.append(leading + COLORS.WARNING + '  - {}: {}'.format(aliases, flag.description) + COLORS.ENDC)
       print('\n'.join(flags_to_print))
-    print('here?')
 
     commands = self.commands[cmd].commands
     cmds_to_print = []

--- a/commands/base.py
+++ b/commands/base.py
@@ -44,6 +44,7 @@ class CommandBase(BaseFunctions):
     flags = self.commands[cmd].flags
 
     flags_to_print = []
+    print('here?')
     if flags is not None and len(flags) > 0:
       has_extra_info = True
       usage_req = [f.aliases[0] for f in flags if f.required and len(f.aliases) == 1]  # if required
@@ -67,10 +68,10 @@ class CommandBase(BaseFunctions):
           aliases += COLORS.RED + ' (optional)' + COLORS.WARNING
         flags_to_print.append(leading + COLORS.WARNING + '  - {}: {}'.format(aliases, flag.description) + COLORS.ENDC)
       print('\n'.join(flags_to_print))
+    print('here?')
 
     commands = self.commands[cmd].commands
     cmds_to_print = []
-    print('here?')
     if commands is not None and len(commands) > 0:
       print(leading + '{}>>  Commands 💻:{}'.format(COLORS.OKGREEN, COLORS.ENDC))
       for cmd in commands:

--- a/commands/base.py
+++ b/commands/base.py
@@ -36,6 +36,7 @@ class CommandBase(BaseFunctions):
       return None, e
 
   def _help(self, cmd, show_description=True, leading=''):
+    print('here?')
     has_extra_info = False
     description = self.commands[cmd].description
     if show_description:

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -11,7 +11,8 @@ class Device(CommandBase):
 
     self.commands = {'battery': Command(description='🔋 see information about the state of your battery'),
                      'reboot': Command(description='⚡ safely reboot your device'),
-                     'shutdown': Command(description='🔌 safely shutdown your device'),
+                     'shutdown': Command(description='🔌 safely shutdown your device',
+                                         flags=[Flag(['-r', '--reboot'], 'An alternate way to reboot the device', dtype='bool')]),
                      'settings': Command(description='⚙️ open the Settings app')}
 
   def _settings(self):
@@ -23,6 +24,10 @@ class Device(CommandBase):
     success('👋 See you in a bit!')
 
   def _shutdown(self):
+    flags, e = self.parse_flags(self.commands['switch'].parser)
+    if e is None and flags.reboot:
+      self._reboot()
+      return
     check_output('am start -n android/com.android.internal.app.ShutdownActivity')
     success('🌙 Goodnight!')
 

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -24,7 +24,7 @@ class Device(CommandBase):
     success('👋 See you in a bit!')
 
   def _shutdown(self):
-    flags, e = self.parse_flags(self.commands['switch'].parser)
+    flags, e = self.parse_flags(self.commands['shutdown'].parser)
     if e is None and flags.reboot:
       self._reboot()
       return

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -316,7 +316,7 @@ class Fork(CommandBase):
           return True
       self.fork_params.put('setup_complete', False)  # some error with base origin, reclone
       self.fork_params.reset()
-    warning('There was an error with your clone of commaai/openpilot, restarting initialization!')
+      warning('There was an error with your clone of commaai/openpilot, restarting initialization!')
 
     info('To set up emu fork management we will clone commaai/openpilot into {}'.format(OPENPILOT_PATH))
     info('Confirm you would like to continue')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -186,7 +186,7 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(flags.username))
 
-    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
+    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username, flags.branch])
     if not r:
       error('Error while fetching remote, please try again')
       return

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -314,7 +314,7 @@ class Fork(CommandBase):
         r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'show'])
         if COMMA_ORIGIN_NAME in r.output.split('\n'):  # sign that we're set up correctly todo: check all forks exist as remotes
           return True
-      self.fork_params.put('setup_complete', False)  # some error with base origin, reclone
+      self.fork_params.put('setup_complete', False)  # renamed origin -> commaai does not exist, restart setup
       self.fork_params.reset()
       warning('There was an error with your clone of commaai/openpilot, restarting initialization!')
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -227,9 +227,9 @@ class Fork(CommandBase):
     remote_branch = f'{username}/{branch}'
     if branch not in installed_forks[username]['installed_branches']:
       info('New branch! Tracking and checking out {} from {}'.format(fork_branch, remote_branch))
-      r = check_output(['git', '-C', OPENPILOT_PATH, 'checkout', '--track', '-b', fork_branch, remote_branch])
-      if not r.success:
-        error(r.output)
+      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', '--track', '-b', fork_branch, remote_branch])
+      if not r:
+        error('Error while checking out branch, please try again')
         return
       self.__add_branch(username, branch)  # we can deduce fork branch from username and original branch f({username}_{branch})
     else:  # already installed branch, checking out fork_branch from remote_branch

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -312,7 +312,7 @@ class Fork(CommandBase):
     if self.fork_params.get('setup_complete'):
       if os.path.exists(OPENPILOT_PATH):
         r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'show'])
-        if COMMA_ORIGIN_NAME in r.output.split('\n'):  # sign that we're set up correctly
+        if COMMA_ORIGIN_NAME in r.output.split('\n'):  # sign that we're set up correctly todo: check all forks exist as remotes
           return True
       self.fork_params.put('setup_complete', False)  # some error with base origin, reclone
       self.fork_params.reset()
@@ -352,3 +352,4 @@ class Fork(CommandBase):
     self.fork_params.put('current_fork', COMMA_ORIGIN_NAME)
     self.fork_params.put('current_branch', COMMA_DEFAULT_BRANCH)
     self.__add_fork(COMMA_ORIGIN_NAME)
+    return True

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -186,9 +186,9 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(flags.username))
 
-    r = check_output(['git', '-C', OPENPILOT_PATH, 'fetch', username])
-    if not r.success:
-      error(r.output)
+    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
+    if not r:
+      error('Error while fetching remote, please try again')
       return
     self.__add_fork(username)
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -186,7 +186,7 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(flags.username))
 
-    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username, flags.branch])
+    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
     if not r:
       error('Error while fetching remote, please try again')
       return

--- a/emu.py
+++ b/emu.py
@@ -16,6 +16,7 @@ DEBUG = not path.exists('/data/params/d')
 
 class Emu(BaseFunctions):
   def __init__(self, args):
+    self.name = 'emu'
     self.args = args
     self.commands = {cmd.name: cmd for cmd in EMU_COMMANDS}
     self.parse()

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ COMMUNITY_BASHRC_PATH=/data/community/.bashrc
 OH_MY_COMMA_PATH=/data/community/.oh-my-comma
 GIT_BRANCH_NAME=master
 GIT_REMOTE_URL=https://github.com/emu-sh/.oh-my-comma.git
-OMC_VERSION=0.1.7
+OMC_VERSION=0.1.8
 
 update=false
 if [ $# -ge 1 ] && [ $1 = "update" ]; then

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -38,7 +38,8 @@ class BaseFunctions:
     max_cmd = max([len(_c) for _c in self.commands]) + 1
     for idx, cmd in enumerate(self.commands):
       desc = COLORS.CYAN + self.commands[cmd].description
-      print(COLORS.OKGREEN + ('- {:<%d} {}' % max_cmd).format('hi '+cmd + ':', desc))
+      print_cmd = 'emu {} {}'.format(self.name, cmd)
+      print(COLORS.OKGREEN + ('- {:<%d} {}' % max_cmd).format(print_cmd + ':', desc))
       if hasattr(self, '_help'):
         # leading is for better differentiating between the different commands
         if self._help(cmd, show_description=False, leading='  '):

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -38,7 +38,7 @@ class BaseFunctions:
     max_cmd = max([len(_c) for _c in self.commands]) + 1
     for idx, cmd in enumerate(self.commands):
       desc = COLORS.CYAN + self.commands[cmd].description
-      print(COLORS.OKGREEN + ('- {:<%d} {}' % max_cmd).format(cmd + ':', desc))
+      print(COLORS.OKGREEN + ('- {:<%d} {}' % max_cmd).format('hi '+cmd + ':', desc))
       if hasattr(self, '_help'):
         # leading is for better differentiating between the different commands
         if self._help(cmd, show_description=False, leading='  '):

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -41,9 +41,8 @@ class BaseFunctions:
       print(COLORS.OKGREEN + ('- {:<%d} {}' % max_cmd).format(cmd + ':', desc))
       if hasattr(self, '_help'):
         # leading is for better differentiating between the different commands
-        self._help(cmd, show_description=False, leading='  ')
-        print('here')
-        print()
+        if self._help(cmd, show_description=False, leading='  '):
+          print()  # only add newline when there's more information to sift through
     print(COLORS.ENDC, end='')
 
   def next_arg(self, lower=True, ingest=True):

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -38,7 +38,9 @@ class BaseFunctions:
     max_cmd = max([len(_c) for _c in self.commands]) + 1
     for idx, cmd in enumerate(self.commands):
       desc = COLORS.CYAN + self.commands[cmd].description
-      print_cmd = 'emu {} {}'.format(self.name, cmd)
+      print_cmd = '{} {}'.format(self.name, cmd)
+      if self.name != 'emu':
+        print_cmd = 'emu {}'.format(print_cmd)
       print(COLORS.OKGREEN + ('- {:<%d} {}' % max_cmd).format(print_cmd + ':', desc))
       if hasattr(self, '_help'):
         # leading is for better differentiating between the different commands

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -42,6 +42,7 @@ class BaseFunctions:
       if hasattr(self, '_help'):
         # leading is for better differentiating between the different commands
         self._help(cmd, show_description=False, leading='  ')
+        print('here')
         print()
     print(COLORS.ENDC, end='')
 


### PR DESCRIPTION
- fixes warning that pops up no matter what telling user fork management is set up incorrectly
- prints the full command name no matter what: `emu device battery`, etc. in `self.print_commands`
- runs the user's fork switch command after setup
- adds a newline only when flags are present