### PR TITLE
Add code for specifying default fork branches and add alias for dragonpilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release 0.2 (2020-08-28)
+=====
+
+* On first setup we now rename local branch `release2` to `commaai_release2`  (removes dangling `release2` branch after setup and switching to stock)
+  * We also now add the `release2` branch to `installed_branches` for the fork so `emu fork list` now shows current branch after immediate set up with no switching
+* Add `dragonpilot` as an alias to `dragonpilot-community/dragonpilot`
+
 Release 0.1.9 (2020-08-12)
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Release 0.2 (2020-08-28)
+Release 0.1.10 (2020-08-28)
 =====
 
 * On first setup we now rename local branch `release2` to `commaai_release2`  (removes dangling `release2` branch after setup and switching to stock)

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -222,6 +222,8 @@ class Fork(CommandBase):
       error('Error: Cannot find default branch from fork!')
       return
 
+    print(flags.branch)
+    print(remote_info)
     if flags.branch is None:  # user hasn't specified a branch, use remote's default branch
       if remote_info is not None:  # todo: check this
         print('{} is branch alias: {}'.format(username, (remote_info.username, remote_info.default_branch)))

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -76,8 +76,8 @@ class Fork(CommandBase):
     self.description = '🍴 Manage installed forks, or install a new one'
 
     self.fork_params = ForkParams()
-    self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'commaai', 'origin'], 'release2'),
-                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot', 'dragonpilot-community'], 'devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
+    self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'origin'], 'release2'),
+                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], 'devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
 
     self.comma_origin_name = 'commaai'
     self.comma_default_branch = self.remote_defaults['commaai'].default_branch
@@ -146,6 +146,7 @@ class Fork(CommandBase):
       remote_info = self.remote_defaults[default_username]
       if username in remote_info.username_aliases:
         remote_info.username = default_username  # add dict key to class instance so we don't have to return a tuple
+        remote_info.username_aliases.append(default_username)  # so default branch works when user enters the actual name
         return remote_info
     return None
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -76,8 +76,8 @@ class Fork(CommandBase):
     self.description = '🍴 Manage installed forks, or install a new one'
 
     self.fork_params = ForkParams()
-    self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'commaai', 'origin'], default_branch='release2'),
-                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], default_branch='devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
+    self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'commaai', 'origin'], 'release2'),
+                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], 'devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
 
     self.comma_origin_name = 'commaai'
     self.comma_default_branch = self.remote_defaults['commaai'].default_branch

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -183,7 +183,10 @@ class Fork(CommandBase):
     fork_in_params = True
     if username not in installed_forks:
       fork_in_params = False
-      remote_url = 'https://github.com/{}/openpilot'.format(username)
+      if remote_info is not None:
+        remote_url = f'https://github.com/{username}/{remote_info.fork_name}'  # dragonpilot doesn't have a GH redirect
+      else:
+        remote_url = f'https://github.com/{username}/openpilot'
 
       if not valid_fork_url(remote_url):
         error('Invalid username! {} does not exist'.format(remote_url))

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -8,8 +8,8 @@ from py_utils.emu_utils import run, error, success, warning, info, is_affirmativ
 from py_utils.emu_utils import OPENPILOT_PATH, FORK_PARAM_PATH, COLORS
 
 GIT_OPENPILOT_URL = 'https://github.com/commaai/openpilot'
-# COMMA_ORIGIN_NAME = 'commaai'
-# COMMA_DEFAULT_BRANCH = 'release2'
+COMMA_ORIGIN_NAME = 'commaai'
+COMMA_DEFAULT_BRANCH = 'release2'
 
 REMOTE_ALREADY_EXISTS = 'already exists'
 DEFAULT_BRANCH_START = 'HEAD branch: '

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -76,7 +76,7 @@ class Fork(CommandBase):
     self.description = '🍴 Manage installed forks, or install a new one'
 
     self.fork_params = ForkParams()
-    self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'origin'], default_branch='release2'),
+    self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'commaai', 'origin'], default_branch='release2'),
                             'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], default_branch='devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
 
     self.comma_origin_name = 'commaai'

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -77,7 +77,8 @@ class Fork(CommandBase):
 
     self.fork_params = ForkParams()
     self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'commaai', 'origin'], 'release2'),
-                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], 'devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
+                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], 'devel-i18n'),
+                            'shanesmiskol': RemoteInfo('openpilot', ['shane'], 'dPoly-offsetting')}  # devel-i18n isn't most stable, but its name remains the same
 
     self.comma_origin_name = 'commaai'
     self.comma_default_branch = self.remote_defaults['commaai'].default_branch

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -382,6 +382,11 @@ class Fork(CommandBase):
     if not r.success:
       error(r.output)
       return
+    # rename release2 to commaai_release2 to align with emu fork standards
+    r = check_output(['git', '-C', OPENPILOT_PATH, 'branch', '-m', f'{self.comma_origin_name}_{self.comma_default_branch}'])
+    if not r.success:
+      error(r.output)
+      return
 
     success('Fork management set up successfully! You\'re on {}/{}'.format(self.comma_origin_name, self.comma_default_branch))
     success('To get started, try running: {}emu fork switch (username) [-b BRANCH]{}'.format(COLORS.RED, COLORS.ENDC))

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -77,8 +77,7 @@ class Fork(CommandBase):
 
     self.fork_params = ForkParams()
     self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'commaai', 'origin'], 'release2'),
-                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], 'devel-i18n'),
-                            'shanesmiskol': RemoteInfo('openpilot', ['shane'], 'dPoly-offsetting')}  # devel-i18n isn't most stable, but its name remains the same
+                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], 'devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
 
     self.comma_origin_name = 'commaai'
     self.comma_default_branch = self.remote_defaults['commaai'].default_branch

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -130,7 +130,7 @@ class Fork(CommandBase):
     else:
       fork = flags.fork.lower()
       remote_info = self.__get_remote_info(fork)
-      if remote_info is not None:
+      if remote_info is not None:  # there's an overriding default username available
         fork = remote_info.username
         flags.fork = remote_info.username
       if fork not in installed_forks:
@@ -175,7 +175,6 @@ class Fork(CommandBase):
     username = flags.username.lower()
     remote_info = self.__get_remote_info(username)
     if remote_info is not None:  # user entered an alias (ex. stock, dragonpilot)
-      print('{} is fork alias: {}'.format(username, (remote_info.username, remote_info.fork_name)))
       username = remote_info.username
       flags.username = remote_info.username
 
@@ -185,7 +184,7 @@ class Fork(CommandBase):
       fork_in_params = False
       if remote_info is not None:
         remote_url = f'https://github.com/{username}/{remote_info.fork_name}'  # dragonpilot doesn't have a GH redirect
-      else:
+      else:  # for most forks, GH will redirect from /openpilot if user renames fork
         remote_url = f'https://github.com/{username}/openpilot'
 
       if not valid_fork_url(remote_url):
@@ -225,11 +224,8 @@ class Fork(CommandBase):
       error('Error: Cannot find default branch from fork!')
       return
 
-    print(flags.branch)
-    print(remote_info)
     if flags.branch is None:  # user hasn't specified a branch, use remote's default branch
-      if remote_info is not None:  # todo: check this
-        print('{} is branch alias: {}'.format(username, (remote_info.username, remote_info.default_branch)))
+      if remote_info is not None:  # there's an overriding default branch specified
         remote_branch = remote_info.default_branch
         local_branch = '{}_{}'.format(remote_info.username, remote_branch)
       else:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -144,9 +144,9 @@ class Fork(CommandBase):
   def __get_remote_info(self, username):
     for default_username in self.remote_defaults:
       remote_info = self.remote_defaults[default_username]
+      remote_info.username = default_username  # add dict key to class instance so we don't have to return a tuple
+      remote_info.username_aliases.append(default_username)  # so default branch works when user enters the actual name
       if username in remote_info.username_aliases:
-        remote_info.username = default_username  # add dict key to class instance so we don't have to return a tuple
-        remote_info.username_aliases.append(default_username)  # so default branch works when user enters the actual name
         return remote_info
     return None
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -140,15 +140,6 @@ class Fork(CommandBase):
       for branch in installed_branches:
         print(' - {}{}{}'.format(COLORS.RED, branch, COLORS.ENDC))
 
-  def __get_remote_info(self, username):
-    for default_username in self.remote_defaults:
-      remote_info = self.remote_defaults[default_username]
-      remote_info.username = default_username  # add dict key to class instance so we don't have to return a tuple
-      remote_info.username_aliases.append(default_username)  # so default branch works when user enters the actual name
-      if username in remote_info.username_aliases:
-        return remote_info
-    return None
-
   def _switch(self):
     if not self._init():
       return
@@ -307,6 +298,15 @@ class Fork(CommandBase):
       else:
         error('Please try again, something went wrong:')
         print(r.output)
+
+  def __get_remote_info(self, username):
+    for default_username in self.remote_defaults:
+      remote_info = self.remote_defaults[default_username]
+      remote_info.username = default_username  # add dict key to class instance so we don't have to return a tuple
+      remote_info.username_aliases.append(default_username)  # so default branch works when user enters the actual name
+      if username in remote_info.username_aliases:
+        return remote_info
+    return None
 
   def __get_remote_branches(self, r):
     # get remote's branches to verify from output of command in parent function

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -77,7 +77,7 @@ class Fork(CommandBase):
 
     self.fork_params = ForkParams()
     self.remote_defaults = {'commaai': RemoteInfo('openpilot', ['stock', 'commaai', 'origin'], 'release2'),
-                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot'], 'devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
+                            'dragonpilot-community': RemoteInfo('dragonpilot', ['dragonpilot', 'dragonpilot-community'], 'devel-i18n')}  # devel-i18n isn't most stable, but its name remains the same
 
     self.comma_origin_name = 'commaai'
     self.comma_default_branch = self.remote_defaults['commaai'].default_branch

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -175,7 +175,7 @@ class Fork(CommandBase):
     username = flags.username.lower()
     remote_info = self.__get_remote_info(username)
     if remote_info is not None:  # user entered an alias (ex. stock, dragonpilot)
-      print('{} is alias: {}'.format(username, (remote_info.username, remote_info.fork_name)))
+      print('{} is fork alias: {}'.format(username, (remote_info.username, remote_info.fork_name)))
       username = remote_info.username
       flags.username = remote_info.username
 
@@ -224,6 +224,7 @@ class Fork(CommandBase):
 
     if flags.branch is None:  # user hasn't specified a branch, use remote's default branch
       if remote_info is not None:  # todo: check this
+        print('{} is branch alias: {}'.format(username, (remote_info.username, remote_info.default_branch)))
         remote_branch = remote_info.default_branch
         local_branch = '{}_{}'.format(remote_info.username, remote_branch)
       else:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -8,7 +8,6 @@ from py_utils.emu_utils import run, error, success, warning, info, is_affirmativ
 from py_utils.emu_utils import OPENPILOT_PATH, FORK_PARAM_PATH, COLORS
 
 GIT_OPENPILOT_URL = 'https://github.com/commaai/openpilot'
-
 REMOTE_ALREADY_EXISTS = 'already exists'
 DEFAULT_BRANCH_START = 'HEAD branch: '
 REMOTE_BRANCHES_START = 'Remote branches:\n'

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@
 
 # This is the install script for https://emu.sh/
 # Located on git at https://github.com/emu-sh/.oh-my-comma
-# To install this, ssh into your comma device and paste: '
+# To install this, ssh into your comma device and paste:
 '
 bash <(curl -fsSL install.emu.sh) # the brain of the bird
 source /home/.bashrc

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ if [ ${CURRENT_BRANCH} != "master" ]; then
 fi
 
 echo "Current version: $OMC_VERSION"
-printf "\033[0mYou may need to run the following to reflect the update:\n \033[92msource ${OH_MY_COMMA_PATH}/emu.sh"
+printf "\033[0mYou may need to run the following to reflect the update:\n\033[92msource ${OH_MY_COMMA_PATH}/emu.sh"
 printf "\033[0m\n\n"
 
 if [ $update = false ]; then

--- a/install.sh
+++ b/install.sh
@@ -141,11 +141,11 @@ fi
 
 printf "\033[92m"
 if [ $update = true ]; then
-  printf "\nSuccessfully updated emu utilities!\n"
+  printf "Successfully updated emu utilities!\n"
 else
   echo "Sourcing /home/.bashrc to apply the changes made during installation"
   source /home/.bashrc
-  printf "Successfully installed emu utilities\n\n"
+  printf "\nSuccessfully installed emu utilities\n\n"
 fi
 
 CURRENT_BRANCH=$(cd ${OH_MY_COMMA_PATH} && git rev-parse --abbrev-ref HEAD)

--- a/install.sh
+++ b/install.sh
@@ -17,10 +17,8 @@
 # This is the install script for https://emu.sh/
 # Located on git at https://github.com/emu-sh/.oh-my-comma
 # To install this, ssh into your comma device and paste:
-"
-bash <(curl -fsSL install.emu.sh) # the brain of the bird
-source /home/.bashrc
-"
+# bash <(curl -fsSL install.emu.sh) # the brain of the bird
+# source /home/.bashrc
 
 SYSTEM_BASHRC_PATH=/home/.bashrc
 COMMUNITY_PATH=/data/community

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ if [ ! -x "$(command -v powerline-shell)" ] && [ $update = false ]; then
 fi
 
 if [ $update = true ]; then
-  echo "Installing emu utilities..."
+  echo "\nInstalling emu utilities..."
 fi
 
 echo "Remounting /system as rewritable (until NEOS 15)"

--- a/install.sh
+++ b/install.sh
@@ -150,7 +150,7 @@ fi
 
 CURRENT_BRANCH=$(cd ${OH_MY_COMMA_PATH} && git rev-parse --abbrev-ref HEAD)
 if [ ${CURRENT_BRANCH} != "master" ]; then
-  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. If this is unintentional, run:\n\033[92mgit -C /data/community/.oh-my-comma checkout master\033[0m\n"
+  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. If this is unintentional, run:\n\033[92mgit -C /data/community/.oh-my-comma checkout master\033[0m\n\n"
 fi
 
 echo "Current version: $OMC_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -17,10 +17,10 @@
 # This is the install script for https://emu.sh/
 # Located on git at https://github.com/emu-sh/.oh-my-comma
 # To install this, ssh into your comma device and paste:
-'
-bash <(curl -fsSL install.emu.sh) # the brain of the bird
-source /home/.bashrc
-'
+#'
+#bash <(curl -fsSL install.emu.sh) # the brain of the bird
+#source /home/.bashrc
+#'
 
 SYSTEM_BASHRC_PATH=/home/.bashrc
 COMMUNITY_PATH=/data/community

--- a/install.sh
+++ b/install.sh
@@ -145,7 +145,7 @@ if [ $update = true ]; then
 else
   echo "Sourcing /home/.bashrc to apply the changes made during installation"
   source /home/.bashrc
-  printf "\nSuccessfully installed emu utilities\n\n"
+  printf "Successfully installed emu utilities\n\n"
 fi
 
 CURRENT_BRANCH=$(cd ${OH_MY_COMMA_PATH} && git rev-parse --abbrev-ref HEAD)

--- a/install.sh
+++ b/install.sh
@@ -150,7 +150,7 @@ fi
 
 CURRENT_BRANCH=$(cd ${OH_MY_COMMA_PATH} && git rev-parse --abbrev-ref HEAD)
 if [ ${CURRENT_BRANCH} != "master" ]; then
-  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. Run \033[92git -C /data/community/.oh-my-comma checkout master\033[0m if this is unintentional\n"
+  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. Run \033[92mgit -C /data/community/.oh-my-comma checkout master\033[0m if this is unintentional\n"
 fi
 
 echo "Current version: $OMC_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -150,7 +150,7 @@ fi
 
 CURRENT_BRANCH=$(cd ${OH_MY_COMMA_PATH} && git rev-parse --abbrev-ref HEAD)
 if [ ${CURRENT_BRANCH} != "master" ]; then
-  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. Run \033[92mgit -C /data/community/.oh-my-comma checkout master\033[0m if this is unintentional\n"
+  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. If this is unintentional, run:\n\033[92mgit -C /data/community/.oh-my-comma checkout master\033[0m\n"
 fi
 
 echo "Current version: $OMC_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -150,7 +150,7 @@ fi
 
 CURRENT_BRANCH=$(cd ${OH_MY_COMMA_PATH} && git rev-parse --abbrev-ref HEAD)
 if [ ${CURRENT_BRANCH} != "master" ]; then
-  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. Run git -C /data/community/.oh-my-comma checkout master if this is unintentional\n"
+  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is ${CURRENT_BRANCH}. Run \033[92git -C /data/community/.oh-my-comma checkout master\033[0m if this is unintentional\n"
 fi
 
 echo "Current version: $OMC_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -17,10 +17,10 @@
 # This is the install script for https://emu.sh/
 # Located on git at https://github.com/emu-sh/.oh-my-comma
 # To install this, ssh into your comma device and paste:
-#'
-#bash <(curl -fsSL install.emu.sh) # the brain of the bird
-#source /home/.bashrc
-#'
+"
+bash <(curl -fsSL install.emu.sh) # the brain of the bird
+source /home/.bashrc
+"
 
 SYSTEM_BASHRC_PATH=/home/.bashrc
 COMMUNITY_PATH=/data/community


### PR DESCRIPTION
- On first setup we now rename local branch `release2` to `commaai_release2`  (removes dangling `release2` branch after setup and switching to stock)
  - We also now add the `release2` branch to `installed_branches` for the fork so `emu fork list` now shows current branch after immediate set up with no switching
- Add `dragonpilot` as an alias to `dragonpilot-community/dragonpilot`

![Screenshot_64](https://user-images.githubusercontent.com/25857203/91624590-d94f2480-e966-11ea-89c2-f58b03f88c11.png)
