### PR TITLE
Fix for submodules that refuse to init, various improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Release 0.1.12 (2020-10-22)
+=====
+
+* Force reinitializes when submodules detected on the branch we're switching to
+  * Fixes openpilot not starting when switching away and back to a branch with submodule
+* Show what git is doing when switching branches (make checkout verbose)
+* Speed up switching by ~300ms by only pruning once every 24 hrs.
+* Add `--force` flag to switch command, same as `git checkout -f`
+* Fix `shutdown` command happily taking any argument without error, defaulting to shutdown when not `-r`
+* Add x emoji (❌) prepended to all errors using error function, makes errors stand out more.
+
+
 Release 0.1.11 (2020-10-05)
 =====
 

--- a/commands/base.py
+++ b/commands/base.py
@@ -3,6 +3,7 @@
 from py_utils.colors import COLORS
 from py_utils.emu_utils import ArgumentParser, BaseFunctions, success, error
 
+
 class CommandBase(BaseFunctions):
   def __init__(self):
     self.name = ''
@@ -77,6 +78,7 @@ class CommandBase(BaseFunctions):
       print('\n'.join(cmds_to_print))
     return has_extra_info
 
+
 class Flag:
   def __init__(self, aliases, description, required=False, dtype='bool'):
     if isinstance(aliases, str):
@@ -88,6 +90,7 @@ class Flag:
     self.dtype = dtype
     if self.required and self.aliases[0][0] == '-':
       raise Exception('Positional arguments cannot be required!')
+
 
 class Command:
   def __init__(self, description=None, commands=None, flags=None):

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -25,7 +25,12 @@ class Device(CommandBase):
 
   def _shutdown(self):
     flags, e = self.parse_flags(self.commands['shutdown'].parser)
-    if e is None and flags.reboot:
+    if e is not None:
+      error(e)
+      self._help('switch')
+      return
+
+    if flags.reboot:
       self.__reboot()
       return
     # check_output('am start -n android/com.android.internal.app.ShutdownActivity')

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from commands.base import CommandBase, Command, Flag
-from py_utils.emu_utils import run, warning, error, check_output, COLORS, success
+from py_utils.emu_utils import error, check_output, COLORS, success
 
 
 class Device(CommandBase):

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -3,6 +3,7 @@
 from commands.base import CommandBase, Command, Flag
 from py_utils.emu_utils import run, warning, error, check_output, COLORS, success
 
+
 class Device(CommandBase):
   def __init__(self):
     super().__init__()
@@ -12,15 +13,17 @@ class Device(CommandBase):
     self.commands = {'battery': Command(description='🔋 see information about the state of your battery'),
                      'reboot': Command(description='⚡ safely reboot your device'),
                      'shutdown': Command(description='🔌 safely shutdown your device',
-                                         flags=[Flag(['-r', '--reboot'], 'Safely reboot the device', dtype='bool')]),
+                                         flags=[Flag(['-r', '--reboot'], 'An alternate way to reboot your device', dtype='bool')]),
                      'settings': Command(description='⚙️ open the Settings app')}
 
-  def _settings(self):
+  @staticmethod
+  def _settings():
     check_output('am start -a android.settings.SETTINGS')
     success('⚙️ Opened settings!')
 
-  def __reboot(self):
-    # check_output('am start -a android.intent.action.REBOOT')
+  @staticmethod
+  def __reboot():
+    check_output('am start -a android.intent.action.REBOOT')
     success('👋 See you in a bit!')
 
   def _shutdown(self):
@@ -33,10 +36,11 @@ class Device(CommandBase):
     if flags.reboot:
       self.__reboot()
       return
-    # check_output('am start -n android/com.android.internal.app.ShutdownActivity')
+    check_output('am start -n android/com.android.internal.app.ShutdownActivity')
     success('🌙 Goodnight!')
 
-  def _battery(self):
+  @staticmethod
+  def _battery():
     r = check_output('dumpsys batterymanager')
     if not r:
       error('Unable to get battery status!')

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -12,7 +12,7 @@ class Device(CommandBase):
     self.commands = {'battery': Command(description='🔋 see information about the state of your battery'),
                      'reboot': Command(description='⚡ safely reboot your device'),
                      'shutdown': Command(description='🔌 safely shutdown your device',
-                                         flags=[Flag(['-r', '--reboot'], 'An alternate way to reboot the device', dtype='bool')]),
+                                         flags=[Flag(['-r', '--reboot'], 'Safely reboot the device', dtype='bool')]),
                      'settings': Command(description='⚙️ open the Settings app')}
 
   def _settings(self):

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -19,16 +19,16 @@ class Device(CommandBase):
     check_output('am start -a android.settings.SETTINGS')
     success('⚙️ Opened settings!')
 
-  def _reboot(self):
-    check_output('am start -a android.intent.action.REBOOT')
+  def __reboot(self):
+    # check_output('am start -a android.intent.action.REBOOT')
     success('👋 See you in a bit!')
 
   def _shutdown(self):
     flags, e = self.parse_flags(self.commands['shutdown'].parser)
     if e is None and flags.reboot:
-      self._reboot()
+      self.__reboot()
       return
-    check_output('am start -n android/com.android.internal.app.ShutdownActivity')
+    # check_output('am start -n android/com.android.internal.app.ShutdownActivity')
     success('🌙 Goodnight!')
 
   def _battery(self):

--- a/commands/device/__init__.py
+++ b/commands/device/__init__.py
@@ -27,7 +27,7 @@ class Device(CommandBase):
     flags, e = self.parse_flags(self.commands['shutdown'].parser)
     if e is not None:
       error(e)
-      self._help('switch')
+      self._help('shutdown')
       return
 
     if flags.reboot:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -311,12 +311,10 @@ class Fork(CommandBase):
         print(' - {}{}'.format(cb, COLORS.ENDC))
 
   def __prune_remote_branches(self, username):  # remove deleted remote branches locally
-    # TODO: Limit this operation to once every day. Takes about 300 ms every switch command
     last_prune = self.fork_params.get('last_prune')
     if isinstance(last_prune, str) and datetime.now().strftime("%d") == last_prune:
-      print('not pruning, still same day')
       return
-    print('days different, pruning!')
+    self.fork_params.put('last_prune', datetime.now().strftime("%d"))
 
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'prune', username, '--dry-run'])
     if r.output == '':  # nothing to prune
@@ -335,7 +333,6 @@ class Fork(CommandBase):
       else:
         error('Please try again, something went wrong:')
         print(r.output)
-    self.fork_params.put('last_prune', datetime.now().strftime("%d"))
 
   def __get_remote_info(self, username):
     for default_username in self.remote_defaults:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,7 +281,7 @@ class Fork(CommandBase):
     reinit_subs = self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    info('\n✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    info('✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     if reinit_subs:
       info('✅ Successfully reinitialized submodules!')
     print()

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -285,7 +285,6 @@ class Fork(CommandBase):
     if reinit_subs:
       info('✅ Successfully reinitialized submodules!')
 
-
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')
     if username not in installed_forks:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -272,7 +272,10 @@ class Fork(CommandBase):
         command.append('-f')
       r = run(command)
       if not r:
-        error('Error while checking out branch, please try again')
+        if 'would be overwritten' in r:
+          error('Run the same command with -f flag to proceed and overwrite any changes')
+        else:
+          error('Error while checking out branch, please try again')
         return
       self.__add_branch(username, remote_branch)  # we can deduce fork branch from username and original branch f({username}_{branch})
     else:  # already installed branch, checking out fork_branch from f'{username}/{branch}'
@@ -281,8 +284,13 @@ class Fork(CommandBase):
         command.append('-f')
       r = run(command)
       if not r:
-        error('Error while checking out branch, please try again')
+        if 'would be overwritten' in r:
+          error('Run the same command with -f flag to proceed and overwrite any changes')
+        else:
+          error('Error while checking out branch, please try again')
         return
+
+
     td.print('git checkout')
     # reset to remote/branch just to ensure we checked out fully. if remote branch has been force pushed, this will also reset local to remote
     r = check_output(['git', '-C', OPENPILOT_PATH, 'reset', '--hard', f'{username}/{remote_branch}'])
@@ -393,9 +401,9 @@ class Fork(CommandBase):
     default_branch = default_branch[:end_default_branch]
     return remote_branches, default_branch
 
-  def __init_submodules(self):
+  @staticmethod
+  def __init_submodules():
     r = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'status'])
-    print(len(r.output))
     if len(r.output):
       info('Submodules detected, reinitializing!')
       r0 = check_output(['git', 'submodule', 'deinit', '--all', '-f'])

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -222,7 +222,7 @@ class Fork(CommandBase):
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
     td = TimeDebugger('ms', silent=False)
-    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username, '--dry-run'])
+    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
     td.print('git fetch')
     if not r:
       error('Error while fetching remote, please try again')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -383,8 +383,8 @@ class Fork(CommandBase):
     r = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'status'])
     if len(r.output):
       info('Submodules detected, reinitializing!')
-      r0 = check_output(['git', 'submodule', 'deinit', '--all', '-f'])
-      r1 = check_output(['git', 'submodule', 'update', '--init', '--recursive'])
+      r0 = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'deinit', '--all', '-f'])
+      r1 = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'update', '--init', '--recursive'])
       if not r0.success or not r1.success:
         error('Error reinitializing submodules for this branch!')
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -212,7 +212,7 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
-    td = TimeDebugger('ms')
+    td = TimeDebugger('ms', silent=True)
     r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
     td.print('git fetch')
     if not r:
@@ -301,7 +301,8 @@ class Fork(CommandBase):
           cb = COLORS.CYAN + cb
         print(' - {}{}'.format(cb, COLORS.ENDC))
 
-  def __prune_remote_branches(self, username):  # remove deleted remote branches locally
+  @staticmethod
+  def __prune_remote_branches(username):  # remove deleted remote branches locally
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'prune', username, '--dry-run'])
     if r.output == '':  # nothing to prune
       return

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -368,6 +368,7 @@ class Fork(CommandBase):
     end_default_branch = default_branch.index('\n')
     default_branch = default_branch[:end_default_branch]
     td.print('get default branch')
+    td.print(total=True)
     return remote_branches, default_branch
 
   # def _reset_hard(self):  # todo: this functionality

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -230,7 +230,7 @@ class Fork(CommandBase):
     td.reset()
     self.__add_fork(username)
     td.print('__add_fork function')
-    self.fork_params.put('last_prune', '16')
+
     self.__prune_remote_branches(username)
     td.print('prune remote branches')
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'show', username])
@@ -335,7 +335,6 @@ class Fork(CommandBase):
       else:
         error('Please try again, something went wrong:')
         print(r.output)
-
     self.fork_params.put('last_prune', datetime.now().strftime("%d"))
 
   def __get_remote_info(self, username):

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -228,6 +228,7 @@ class Fork(CommandBase):
     td.print('remote show')
     remote_branches, default_remote_branch = self.__get_remote_branches(r)
     td.print('__get_remote_branches')
+    td.print(total=True)
     if remote_branches is None:
       return
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,7 +281,7 @@ class Fork(CommandBase):
     reinit_subs = self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    info('\n✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    info('\n✅ Successfully checked {}/{} out as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     if reinit_subs:
       success('✅ Successfully reinitialized submodules!')
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -217,7 +217,6 @@ class Fork(CommandBase):
         return
 
     # fork has been added as a remote, switch to it
-
     if fork_in_params:
       info('Fetching {}\'s latest changes...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
     else:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -104,7 +104,7 @@ class Fork(CommandBase):
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
                                        flags=[Flag('username', '👤 The username of the fork\'s owner to switch to, will use current fork if not provided', required=False, dtype='str'),
                                               Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str'),
-                                              Flag(['-f', '--force'], '🏋️‍♀️Similar to checkout -f, force checks out new branch overwriting any changes')]),
+                                              Flag(['-f', '--force'], '🏋️‍♀️ Similar to checkout -f, force checks out new branch overwriting any changes')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -5,7 +5,7 @@ import os
 import json
 from datetime import datetime
 from commands.base import CommandBase, Command, Flag
-from py_utils.emu_utils import run, error, success, warning, info, is_affirmative, check_output, most_similar, TimeDebugger
+from py_utils.emu_utils import run, error, success, warning, info, is_affirmative, check_output, most_similar
 from py_utils.emu_utils import OPENPILOT_PATH, FORK_PARAM_PATH, COLORS, OH_MY_COMMA_PATH
 
 GIT_OPENPILOT_URL = 'https://github.com/commaai/openpilot'

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -376,6 +376,7 @@ class Fork(CommandBase):
       shutil.rmtree('/data/community/forks')  # remove to save space
     if self.fork_params.get('setup_complete'):
       if os.path.exists(OPENPILOT_PATH):
+        print('remote show init!')
         r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'show'])
         if self.comma_origin_name in r.output.split('\n'):  # sign that we're set up correctly todo: check all forks exist as remotes
           return True

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -279,8 +279,6 @@ class Fork(CommandBase):
       return
 
     self.__init_submodules()
-
-
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
     success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -223,21 +223,15 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
-    td = TimeDebugger('ms', silent=False)
     r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
-    td.print('git fetch')
     if not r:
       error('Error while fetching remote, please try again')
       return
 
     self.__add_fork(username)
     self.__prune_remote_branches(username)
-
-    td.reset()
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'show', username])
-    td.print('remote show')
     remote_branches, default_remote_branch = self.__get_remote_branches(r)
-
     if remote_branches is None:
       return
 
@@ -245,7 +239,6 @@ class Fork(CommandBase):
       error('Error: Cannot find default branch from fork!')
       return
 
-    td.reset()
     if branch is None:  # user hasn't specified a branch, use remote's default branch
       if remote_info is not None:  # there's an overriding default branch specified
         remote_branch = remote_info.default_branch
@@ -263,7 +256,6 @@ class Fork(CommandBase):
     else:
       error('Error with branch!')
       return
-    td.print('branch parsing')
 
     # checkout remote branch and prepend username so we can have multiple forks with same branch names locally
     if remote_branch not in installed_forks[username]['installed_branches']:
@@ -280,10 +272,8 @@ class Fork(CommandBase):
       return
     self.__add_branch(username, remote_branch)  # we can deduce fork branch from username and original branch f({username}_{branch})
 
-    td.print('git checkout')
     # reset to remote/branch just to ensure we checked out fully. if remote branch has been force pushed, this will also reset local to remote
     r = check_output(['git', '-C', OPENPILOT_PATH, 'reset', '--hard', f'{username}/{remote_branch}'])
-    td.print('reset --hard')
     if not r.success:
       error(r.output)
       return
@@ -294,7 +284,6 @@ class Fork(CommandBase):
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
     success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))
-    td.print(total=True)
 
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -230,7 +230,7 @@ class Fork(CommandBase):
     td.reset()
     self.__add_fork(username)
     td.print('__add_fork function')
-
+    self.fork_params.put('last_prune', '16')
     self.__prune_remote_branches(username)
     td.print('prune remote branches')
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'show', username])

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -212,7 +212,7 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
-    td = TimeDebugger('ms', silent=True)
+    td = TimeDebugger('ms', silent=False)
     r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
     td.print('git fetch')
     if not r:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -212,7 +212,7 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
-    td = TimeDebugger('ms', silent=True)
+    td = TimeDebugger('ms', silent=False)
     r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
     td.print('git fetch')
     if not r:
@@ -331,13 +331,12 @@ class Fork(CommandBase):
         return remote_info
     return None
 
-  def __get_remote_branches(self, r):
-    td = TimeDebugger('ms')
+  @staticmethod
+  def __get_remote_branches(r):
     # get remote's branches to verify from output of command in parent function
     if not r.success:
       error(r.output)
       return None, None
-    td.print('r.success')
     if REMOTE_BRANCHES_START in r.output:
       start_remote_branches = r.output.index(REMOTE_BRANCHES_START)
       remote_branches_txt = r.output[start_remote_branches + len(REMOTE_BRANCHES_START):].split('\n')
@@ -349,7 +348,6 @@ class Fork(CommandBase):
         if ' ' in b or b == '':  # end of branches
           break
         remote_branches.append(b)
-      td.print('get remote branches')
     elif REMOTE_BRANCH_START in r.output:  # remote has single branch, shouldn't need to handle stale here
       start_remote_branch = r.output.index(REMOTE_BRANCH_START)
       remote_branches = r.output[start_remote_branch + len(REMOTE_BRANCH_START):].split('\n')
@@ -366,8 +364,6 @@ class Fork(CommandBase):
     default_branch = r.output[start_default_branch + len(DEFAULT_BRANCH_START):]
     end_default_branch = default_branch.index('\n')
     default_branch = default_branch[:end_default_branch]
-    td.print('get default branch')
-    td.print(total=True)
     return remote_branches, default_branch
 
   # def _reset_hard(self):  # todo: this functionality

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,10 +281,10 @@ class Fork(CommandBase):
     reinit_subs = self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    info('✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    info('\n✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     if reinit_subs:
       info('✅ Successfully reinitialized submodules!')
-    print()
+
 
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -212,7 +212,7 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
-    td = TimeDebugger()
+    td = TimeDebugger('ms')
     r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
     td.print('git fetch')
     if not r:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -103,7 +103,8 @@ class Fork(CommandBase):
 
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
                                        flags=[Flag('username', '👤 The username of the fork\'s owner to switch to, will use current fork if not provided', required=False, dtype='str'),
-                                              Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str')]),
+                                              Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str'),
+                                              Flag(['-f', '--force'], '🏋️‍♀️Similar to checkout -f, force checks out new branch overwriting any changes')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 
@@ -176,6 +177,8 @@ class Fork(CommandBase):
 
     username = flags.username
     branch = flags.branch
+    force_switch = flags.force
+    print(force_switch)
     if username is None:  # branch is specified, so use current checked out fork/username
       _current_fork = self.fork_params.get('current_fork')
       if _current_fork is not None:  # ...if available

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -283,7 +283,7 @@ class Fork(CommandBase):
     self.fork_params.put('current_branch', remote_branch)
     info('\n✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     if reinit_subs:
-      info('✅ Successfully reinitialized submodules!')
+      success('✅ Successfully reinitialized submodules!')
 
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -324,7 +324,7 @@ class Fork(CommandBase):
     branches_to_prune = [b.strip() for b in r.output.split('\n') if 'would prune' in b]
     branches_to_prune = [b[b.index(username):] for b in branches_to_prune]
 
-    error('\nDeleted remote branches detected:')
+    error('Deleted remote branches detected:', start='\n')
     for b in branches_to_prune:
       print(COLORS.CYAN + '  - {}'.format(b) + COLORS.ENDC)
     warning('\nWould you like to delete them locally?')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -397,6 +397,7 @@ class Fork(CommandBase):
     r = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'status'])
     print(len(r.output))
     if len(r.output):
+      info('Submodules detected, reinitializing!')
       r0 = check_output(['git', 'submodule', 'deinit', '--all', '-f'])
       r1 = check_output(['git', 'submodule', 'update', '--init', '--recursive'])
       if not r0.success or not r1.success:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -245,16 +245,13 @@ class Fork(CommandBase):
       else:
         local_branch = '{}_{}'.format(username, default_remote_branch)
         remote_branch = default_remote_branch  # for command to checkout correct branch from remote, branch is previously None since user didn't specify
-    elif len(branch) > 0:
+    else:
       local_branch = f'{username}_{branch}'
       remote_branch = branch
       if remote_branch not in remote_branches:
         error('The branch you specified does not exist!')
         self.__show_similar_branches(remote_branch, remote_branches)  # if possible
         return
-    else:
-      error('Error with branch!')
-      return
 
     # checkout remote branch and prepend username so we can have multiple forks with same branch names locally
     if remote_branch not in installed_forks[username]['installed_branches']:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -387,7 +387,6 @@ class Fork(CommandBase):
       info('Submodules detected, reinitializing!')
       r0 = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'deinit', '--all', '-f'])
       r1 = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'update', '--init', '--recursive'])
-      r0.success = False
       if not r0.success or not r1.success:
         error('Error reinitializing submodules for this branch!')
       else:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -222,7 +222,7 @@ class Fork(CommandBase):
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
     td = TimeDebugger('ms', silent=False)
-    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
+    r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username, '--dry-run'])
     td.print('git fetch')
     if not r:
       error('Error while fetching remote, please try again')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -236,7 +236,6 @@ class Fork(CommandBase):
     td.print('remote show')
     remote_branches, default_remote_branch = self.__get_remote_branches(r)
 
-    td.print(total=True)
     if remote_branches is None:
       return
 
@@ -286,6 +285,7 @@ class Fork(CommandBase):
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
     success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))
+    td.print(total=True)
 
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -303,6 +303,7 @@ class Fork(CommandBase):
 
   @staticmethod
   def __prune_remote_branches(username):  # remove deleted remote branches locally
+    return
     td = TimeDebugger('ms', silent=False)
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'prune', username, '--dry-run'])
     td.print('remote prune --dry-run')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,7 +281,7 @@ class Fork(CommandBase):
     self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    info('Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    info('✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     # success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))
 
   def __add_fork(self, username, branch=None):

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -104,7 +104,7 @@ class Fork(CommandBase):
     self.commands = {'switch': Command(description='🍴 Switch between any openpilot fork',
                                        flags=[Flag('username', '👤 The username of the fork\'s owner to switch to, will use current fork if not provided', required=False, dtype='str'),
                                               Flag(['-b', '--branch'], '🌿 Branch to switch to, will use default branch if not provided', required=False, dtype='str'),
-                                              Flag(['-f', '--force'], '🏋️‍♀️ Similar to checkout -f, force checks out new branch overwriting any changes')]),
+                                              Flag(['-f', '--force'], '💪 Similar to checkout -f, force checks out new branch overwriting any changes')]),
                      'list': Command(description='📜 See a list of installed forks and branches',
                                      flags=[Flag('fork', '🌿 See branches of specified fork', dtype='str')])}
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -227,16 +227,15 @@ class Fork(CommandBase):
     if not r:
       error('Error while fetching remote, please try again')
       return
-    td.reset()
-    self.__add_fork(username)
-    td.print('__add_fork function')
 
+    self.__add_fork(username)
     self.__prune_remote_branches(username)
-    td.print('prune remote branches')
+
+    td.reset()
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'show', username])
     td.print('remote show')
     remote_branches, default_remote_branch = self.__get_remote_branches(r)
-    td.print('__get_remote_branches')
+
     td.print(total=True)
     if remote_branches is None:
       return
@@ -245,6 +244,7 @@ class Fork(CommandBase):
       error('Error: Cannot find default branch from fork!')
       return
 
+    td.reset()
     if branch is None:  # user hasn't specified a branch, use remote's default branch
       if remote_info is not None:  # there's an overriding default branch specified
         remote_branch = remote_info.default_branch
@@ -262,7 +262,7 @@ class Fork(CommandBase):
     else:
       error('Error with branch!')
       return
-
+    td.print('branch parsing')
     # checkout remote branch and prepend username so we can have multiple forks with same branch names locally
     if remote_branch not in installed_forks[username]['installed_branches']:
       info('New branch! Tracking and checking out {} from {}'.format(local_branch, f'{username}/{remote_branch}'))
@@ -276,8 +276,10 @@ class Fork(CommandBase):
       if not r.success:
         error(r.output)
         return
+    td.print('git checkout')
     # reset to remote/branch just to ensure we checked out fully. if remote branch has been force pushed, this will also reset local to remote
     r = check_output(['git', '-C', OPENPILOT_PATH, 'reset', '--hard', f'{username}/{remote_branch}'])
+    td.print('reset --hard')
     if not r.success:
       error(r.output)
       return

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,7 +281,8 @@ class Fork(CommandBase):
     self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))
+    info('Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username + COLORS.WARNING, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    # success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))
 
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -265,16 +265,21 @@ class Fork(CommandBase):
       return
     td.print('branch parsing')
     # checkout remote branch and prepend username so we can have multiple forks with same branch names locally
-    force_flag = '-f' if force_switch else ''
     if remote_branch not in installed_forks[username]['installed_branches']:
       info('New branch! Tracking and checking out {} from {}'.format(local_branch, f'{username}/{remote_branch}'))
-      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', '--track', '-b', local_branch, f'{username}/{remote_branch}', force_flag])
+      command = ['git', '-C', OPENPILOT_PATH, 'checkout', '--track', '-b', local_branch, f'{username}/{remote_branch}']
+      if force_switch:
+        command.append('-f')
+      r = run(command)
       if not r:
         error('Error while checking out branch, please try again')
         return
       self.__add_branch(username, remote_branch)  # we can deduce fork branch from username and original branch f({username}_{branch})
     else:  # already installed branch, checking out fork_branch from f'{username}/{branch}'
-      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', local_branch, force_flag])
+      command = ['git', '-C', OPENPILOT_PATH, 'checkout', local_branch]
+      if force_switch:
+        command.append('-f')
+      r = run(command)
       if not r:
         error('Error while checking out branch, please try again')
         return

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,9 +281,10 @@ class Fork(CommandBase):
     reinit_subs = self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    info('✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    info('\n✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     if reinit_subs:
       info('✅ Successfully reinitialized submodules!')
+    print()
 
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,7 +281,7 @@ class Fork(CommandBase):
     reinit_subs = self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    info('\n✅ Successfully checked {}/{} out as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    info('\n✅ Successfully checked out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     if reinit_subs:
       success('✅ Successfully reinitialized submodules!')
 

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -278,11 +278,12 @@ class Fork(CommandBase):
       error(r.output)
       return
 
-    self.__init_submodules()
+    reinit_subs = self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
     info('✅ Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
-    # success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))
+    if reinit_subs:
+      info('✅ Successfully reinitialized submodules!')
 
   def __add_fork(self, username, branch=None):
     installed_forks = self.fork_params.get('installed_forks')
@@ -388,6 +389,9 @@ class Fork(CommandBase):
       r1 = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'update', '--init', '--recursive'])
       if not r0.success or not r1.success:
         error('Error reinitializing submodules for this branch!')
+      else:
+        return True
+    return False
 
   def _init(self):
     if os.path.isdir('/data/community/forks'):

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -271,9 +271,9 @@ class Fork(CommandBase):
         return
       self.__add_branch(username, remote_branch)  # we can deduce fork branch from username and original branch f({username}_{branch})
     else:  # already installed branch, checking out fork_branch from f'{username}/{branch}'
-      r = check_output(['git', '-C', OPENPILOT_PATH, 'checkout', local_branch])
-      if not r.success:
-        error(r.output)
+      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', local_branch])
+      if not r:
+        error('Error while checking out branch, please try again')
         return
     td.print('git checkout')
     # reset to remote/branch just to ensure we checked out fully. if remote branch has been force pushed, this will also reset local to remote

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -331,8 +331,7 @@ class Fork(CommandBase):
         return remote_info
     return None
 
-  @staticmethod
-  def __get_remote_branches(r):
+  def __get_remote_branches(self, r):
     td = TimeDebugger('ms')
     # get remote's branches to verify from output of command in parent function
     if not r.success:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -281,7 +281,7 @@ class Fork(CommandBase):
     self.__init_submodules()
     self.fork_params.put('current_fork', username)
     self.fork_params.put('current_branch', remote_branch)
-    info('Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username + COLORS.WARNING, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
+    info('Successfully checkout out {}/{} as {}'.format(COLORS.SUCCESS + username, remote_branch + COLORS.WARNING, COLORS.SUCCESS + local_branch))
     # success('Successfully checked out {}/{} as {}'.format(username, remote_branch, local_branch))
 
   def __add_fork(self, username, branch=None):

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -212,7 +212,7 @@ class Fork(CommandBase):
     else:
       info('Fetching {}\'s fork, this may take a sec...'.format(COLORS.SUCCESS + username + COLORS.WARNING))
 
-    td = TimeDebugger('ms', silent=False)
+    td = TimeDebugger('ms', silent=True)
     r = run(['git', '-C', OPENPILOT_PATH, 'fetch', username])
     td.print('git fetch')
     if not r:
@@ -303,11 +303,14 @@ class Fork(CommandBase):
 
   @staticmethod
   def __prune_remote_branches(username):  # remove deleted remote branches locally
+    td = TimeDebugger('ms', silent=False)
     r = check_output(['git', '-C', OPENPILOT_PATH, 'remote', 'prune', username, '--dry-run'])
+    td.print('remote prune --dry-run')
     if r.output == '':  # nothing to prune
       return
     branches_to_prune = [b.strip() for b in r.output.split('\n') if 'would prune' in b]
     branches_to_prune = [b[b.index(username):] for b in branches_to_prune]
+    td.print('list comps')
 
     error('\nDeleted remote branches detected:')
     for b in branches_to_prune:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -387,6 +387,7 @@ class Fork(CommandBase):
       info('Submodules detected, reinitializing!')
       r0 = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'deinit', '--all', '-f'])
       r1 = check_output(['git', '-C', OPENPILOT_PATH, 'submodule', 'update', '--init', '--recursive'])
+      r0.success = False
       if not r0.success or not r1.success:
         error('Error reinitializing submodules for this branch!')
       else:

--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -178,7 +178,6 @@ class Fork(CommandBase):
     username = flags.username
     branch = flags.branch
     force_switch = flags.force
-    print(force_switch)
     if username is None:  # branch is specified, so use current checked out fork/username
       _current_fork = self.fork_params.get('current_fork')
       if _current_fork is not None:  # ...if available
@@ -266,15 +265,16 @@ class Fork(CommandBase):
       return
     td.print('branch parsing')
     # checkout remote branch and prepend username so we can have multiple forks with same branch names locally
+    force_flag = '-f' if force_switch else ''
     if remote_branch not in installed_forks[username]['installed_branches']:
       info('New branch! Tracking and checking out {} from {}'.format(local_branch, f'{username}/{remote_branch}'))
-      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', '--track', '-b', local_branch, f'{username}/{remote_branch}'])
+      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', '--track', '-b', local_branch, f'{username}/{remote_branch}', force_flag])
       if not r:
         error('Error while checking out branch, please try again')
         return
       self.__add_branch(username, remote_branch)  # we can deduce fork branch from username and original branch f({username}_{branch})
     else:  # already installed branch, checking out fork_branch from f'{username}/{branch}'
-      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', local_branch])
+      r = run(['git', '-C', OPENPILOT_PATH, 'checkout', local_branch, force_flag])
       if not r:
         error('Error while checking out branch, please try again')
         return

--- a/commands/panda/__init__.py
+++ b/commands/panda/__init__.py
@@ -5,6 +5,7 @@ from commands.base import CommandBase, Command
 from py_utils.emu_utils import run, error
 from py_utils.emu_utils import OPENPILOT_PATH
 
+
 class Panda(CommandBase):
   def __init__(self):
     super().__init__()
@@ -14,12 +15,14 @@ class Panda(CommandBase):
     self.commands = {'flash': Command(description='🐼 flashes panda with make recover (usually works with the C2)'),
                      'flash2': Command(description='🎍 flashes panda using Panda module (usually works with the EON)')}
 
-  def _flash(self):
+  @staticmethod
+  def _flash():
     r = run('make -C {}/panda/board recover'.format(OPENPILOT_PATH))
     if not r:
       error('Error running make command!')
 
-  def _flash2(self):
+  @staticmethod
+  def _flash2():
     if not run('pkill -f boardd'):
       error('Error killing boardd! Is it running? (continuing...)')
     importlib.import_module('panda', 'Panda').Panda().flash()

--- a/commands/uninstall/__init__.py
+++ b/commands/uninstall/__init__.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-from commands.base import CommandBase, Command, Flag
-from py_utils.emu_utils import run, warning, error, check_output, COLORS, success, input_with_options, UNINSTALL_PATH
+from commands.base import CommandBase
+from py_utils.emu_utils import run, error, input_with_options, UNINSTALL_PATH
+
 
 class Uninstall(CommandBase):
   def __init__(self):
@@ -9,7 +10,8 @@ class Uninstall(CommandBase):
     self.name = 'uninstall'
     self.description = '👋 Uninstalls emu'
 
-  def _uninstall(self):
+  @staticmethod
+  def _uninstall():
     print('Are you sure you want to uninstall emu?')
     if input_with_options(['Y', 'n'], 'n')[0] == 0:
       run(['sh', UNINSTALL_PATH])

--- a/commands/update/__init__.py
+++ b/commands/update/__init__.py
@@ -2,12 +2,14 @@ from commands.base import CommandBase
 from py_utils.emu_utils import run, error
 from py_utils.emu_utils import UPDATE_PATH
 
+
 class Update(CommandBase):
   def __init__(self):
     super().__init__()
     self.name = 'update'
     self.description = '🎉 Updates this tool'
 
-  def _update(self):
+  @staticmethod
+  def _update():
     if not run(['sh', UPDATE_PATH]):
       error('Error updating!')

--- a/emu.py
+++ b/emu.py
@@ -14,6 +14,7 @@ if __package__ is None:
 sys.path.append(OPENPILOT_PATH)  # for importlib
 DEBUG = not path.exists('/data/params/d')
 
+
 class Emu(BaseFunctions):
   def __init__(self, args):
     self.name = 'emu'

--- a/emu.py
+++ b/emu.py
@@ -24,14 +24,12 @@ class Emu(BaseFunctions):
 
   def parse(self):
     cmd = self.next_arg()
-
     if cmd is None:
       self.print_commands(error_msg='You must specify a command for emu. Some options are:', ascii_art=True)
       return
     if cmd not in self.commands:
       self.print_commands(error_msg='Unknown command! Try one of these:')
       return
-
     self.commands[cmd].main(self.args, cmd)
 
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ COMMUNITY_BASHRC_PATH=/data/community/.bashrc
 OH_MY_COMMA_PATH=/data/community/.oh-my-comma
 GIT_BRANCH_NAME=master
 GIT_REMOTE_URL=https://github.com/emu-sh/.oh-my-comma.git
-OMC_VERSION=0.1.11
+OMC_VERSION=0.1.12
 
 install_echo() {  # only prints if not updating
   if [ "$update" != true ]; then

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ fi
 
 CURRENT_BRANCH=$(cd ${OH_MY_COMMA_PATH} && git rev-parse --abbrev-ref HEAD)
 if [ "${CURRENT_BRANCH}" != "master" ]; then
-  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is %s. If this is unintentional, run:\n\033[92mgit -C /data/community/.oh-my-comma checkout master\033[0m\n\n" "${CURRENT_BRANCH}"
+  printf "\n\033[0;31mWarning:\033[0m your current .oh-my-comma git branch is %s. If this is unintentional, run:\n\033[92mgit -C /data/community/.oh-my-comma checkout master\033[0m\n" "${CURRENT_BRANCH}"
 fi
 
 install_echo "Current version: $OMC_VERSION"  # prints in update.sh

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -186,7 +186,7 @@ def error(msg, end='\n', ret=False, start=''):
   :param ret: Whether to return the formatted string, or print it
   :return: The formatted string if ret is True
   """
-  e = '❌' + start + '{}{}{}'.format(COLORS.FAIL, msg, COLORS.ENDC)
+  e = start + '❌ {}{}{}'.format(COLORS.FAIL, msg, COLORS.ENDC)
   if ret:
     return e
   print(e, end=end)

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -152,6 +152,7 @@ def run(cmd, out_file=None):
 
   try:
     r = subprocess.call(cmd, stdout=f)
+    print(r)
     return not r
   except (Exception, KeyboardInterrupt) as e:
     # print(e)

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -32,20 +32,26 @@ class ArgumentParser(argparse.ArgumentParser):
 class TimeDebugger:
   def __init__(self, round_to=4):
     self.round_to = round_to
-    self.reset()
+    self.reset(full=True)
 
-  def reset(self):
+  def reset(self, full=False):
     self.last_time = time.time()
+    if full:
+      self.start_time = self.last_time
 
-  def print(self, msg=None):
-    elapsed = time.time() - self.last_time
+  def print(self, msg=None, total=False):
+    elapsed = round(time.time() - self.last_time, self.round_to)
     if msg is not None:
       msg = 'Time to {}'.format(msg)
     else:
       msg = 'Time elapsed'
-    print('{}: {} sec.'.format(msg, round(elapsed, self.round_to)))
+    print('{}: {} sec.'.format(msg, elapsed))
 
-    self.reset()
+    if total:
+      elapsed = round(time.time() - self.start_time, self.round_to)
+      print('Total: {} sec.'.format(elapsed))
+
+    self.reset(total)
 
 
 class BaseFunctions:

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -30,7 +30,9 @@ class ArgumentParser(argparse.ArgumentParser):
 
 
 class TimeDebugger:
-  def __init__(self, round_to=4):
+  def __init__(self, convention='s', round_to=4):
+    assert convention in ['s', 'ms'], 'Must be "s" or "ms"!'
+    self.convention = convention
     self.round_to = round_to
     self.reset(full=True)
 
@@ -40,16 +42,18 @@ class TimeDebugger:
       self.start_time = self.last_time
 
   def print(self, msg=None, total=False):
-    elapsed = round(time.time() - self.last_time, self.round_to)
+    elapsed = time.time() - self.last_time
+    elapsed *= 1000 if self.convention == 'ms' else 1
     if msg is not None:
       msg = 'Time to {}'.format(msg)
     else:
       msg = 'Time elapsed'
-    print('{}: {} sec.'.format(msg, elapsed))
+    print('{}: {} {}'.format(msg, round(elapsed, self.round_to), self.convention))
 
     if total:
-      elapsed = round(time.time() - self.start_time, self.round_to)
-      print('Total: {} sec.'.format(elapsed))
+      elapsed = time.time() - self.start_time
+      elapsed *= 1000 if self.convention == 'ms' else 1
+      print('Total: {} {}'.format(round(elapsed, self.round_to), self.convention))
 
     self.reset(total)
 

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -42,15 +42,15 @@ class TimeDebugger:
       self.start_time = self.last_time
 
   def print(self, msg=None, total=False):
-    elapsed = time.time() - self.last_time
-    elapsed *= 1000 if self.convention == 'ms' else 1
-    if msg is not None:
-      msg = 'Time to {}'.format(msg)
+    if not total:
+      elapsed = time.time() - self.last_time
+      elapsed *= 1000 if self.convention == 'ms' else 1
+      if msg is not None:
+        msg = 'Time to {}'.format(msg)
+      else:
+        msg = 'Time elapsed'
+      print('{}: {} {}'.format(msg, round(elapsed, self.round_to), self.convention))
     else:
-      msg = 'Time elapsed'
-    print('{}: {} {}'.format(msg, round(elapsed, self.round_to), self.convention))
-
-    if total:
       elapsed = time.time() - self.start_time
       elapsed *= 1000 if self.convention == 'ms' else 1
       print('Total: {} {}'.format(round(elapsed, self.round_to), self.convention))

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -178,7 +178,7 @@ def is_affirmative():
   return i in ['y', 'yes', 'sure', '']
 
 
-def error(msg, end='\n', ret=False):
+def error(msg, end='\n', ret=False, start=''):
   """
   The following applies to error, warning, and success methods
   :param msg: The message to display
@@ -186,7 +186,7 @@ def error(msg, end='\n', ret=False):
   :param ret: Whether to return the formatted string, or print it
   :return: The formatted string if ret is True
   """
-  e = '❌ {}{}{}'.format(COLORS.FAIL, msg, COLORS.ENDC)
+  e = '❌' + start + '{}{}{}'.format(COLORS.FAIL, msg, COLORS.ENDC)
   if ret:
     return e
   print(e, end=end)

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -186,7 +186,7 @@ def error(msg, end='\n', ret=False):
   :param ret: Whether to return the formatted string, or print it
   :return: The formatted string if ret is True
   """
-  e = '{}{}{}'.format(COLORS.FAIL, msg, COLORS.ENDC)
+  e = '❌ {}{}{}'.format(COLORS.FAIL, msg, COLORS.ENDC)
   if ret:
     return e
   print(e, end=end)

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -30,10 +30,11 @@ class ArgumentParser(argparse.ArgumentParser):
 
 
 class TimeDebugger:
-  def __init__(self, convention='s', round_to=4):
+  def __init__(self, convention='s', round_to=4, silent=False):
     assert convention in ['s', 'ms'], 'Must be "s" or "ms"!'
     self.convention = convention
     self.round_to = round_to
+    self.silent = silent
     self.reset(full=True)
 
   def reset(self, full=False):
@@ -42,6 +43,8 @@ class TimeDebugger:
       self.start_time = self.last_time
 
   def print(self, msg=None, total=False):
+    if self.silent:
+      return
     if not total:
       elapsed = time.time() - self.last_time
       elapsed *= 1000 if self.convention == 'ms' else 1

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -138,7 +138,7 @@ def check_output(cmd, cwd=None):
     return Output(e.output)  # command executed but it resulted in error
 
 
-def run(cmd, out_file=None):
+def run(cmd, out_file=None):  # todo: return output with same format as check_output, but also output to user (current behavior)
   """
   If cmd is a string, it is split into a list, otherwise it doesn't modify cmd.
   The status is returned, True being success, False for failure
@@ -152,7 +152,6 @@ def run(cmd, out_file=None):
 
   try:
     r = subprocess.call(cmd, stdout=f)
-    print(r)
     return not r
   except (Exception, KeyboardInterrupt) as e:
     # print(e)

--- a/py_utils/emu_utils.py
+++ b/py_utils/emu_utils.py
@@ -6,8 +6,10 @@ import difflib
 import argparse
 import subprocess
 import time
+
 if __package__ is None:
   from os import path
+
   sys.path.append(path.abspath(path.join(path.dirname(__file__), '../py_utils')))
   from py_utils.colors import COLORS
 else:
@@ -57,7 +59,6 @@ class TimeDebugger:
       elapsed = time.time() - self.start_time
       elapsed *= 1000 if self.convention == 'ms' else 1
       print('Total: {} {}'.format(round(elapsed, self.round_to), self.convention))
-
     self.reset(total)
 
 
@@ -128,6 +129,7 @@ def check_output(cmd, cwd=None):
     def __init__(self, output='', s=True):
       self.output = output
       self.success = s
+
   if isinstance(cmd, str):
     cmd = cmd.split()
   try:


### PR DESCRIPTION
- Force de-inits and reinits when submodules detected on the branch we're switching to
  - Fixes openpilot not starting when switching away and back to a branch with submodules (eg. master or a fork based on master)
- Show what git is doing when switching branches (make checkout verbose)
- Speed up switching by ~300ms by only checking and pruning once every 24 hrs.
- Add `--force` flag to switch command, same as `git checkout -f`
- Fix `shutdown` command happily taking any argument without error, defaulting to shutdown when not `-r`
- Add x emoji (❌) prepended to all errors using error function, makes errors stand out more.

Minor changes:
- Made methods static
- Removed unused imports
- Fixed some PEP8 spacing

Here's what switching to a branch without submodules vs. with looks like:

![Screenshot_87](https://user-images.githubusercontent.com/25857203/96172604-49504480-0eec-11eb-901a-21aa4eabde94.png)

And if there's an error: 

![Screenshot_88](https://user-images.githubusercontent.com/25857203/96173084-f3c86780-0eec-11eb-862a-82010b9e710f.png)