### PR TITLE
`--reference-if-able` the openpilot backup on initial install

### DIFF
--- a/commands/fork/__init__.py
+++ b/commands/fork/__init__.py
@@ -418,7 +418,17 @@ class Fork(CommandBase):
       success('Backed up your current openpilot install to {}'.format(bak_dir))
 
     info('Cloning commaai/openpilot into {}, please wait...'.format(OPENPILOT_PATH))
-    r = run(['git', 'clone', '-b', self.comma_default_branch, GIT_OPENPILOT_URL, OPENPILOT_PATH])  # default to stock/release2 for setup
+    r = run(
+      [
+        'git',
+        'clone',
+        '--reference-if-able',
+        '{}.bak'.format(OPENPILOT_PATH),
+        '-b',
+        self.comma_default_branch,
+        GIT_OPENPILOT_URL,
+        OPENPILOT_PATH]
+    )  # default to stock/release2 for setup
     if not r:
       error('Error while cloning, please try again')
       return


### PR DESCRIPTION
Closes #65

To be honest, I haven't tested this as I'm not an active user of OMC. 

This should do it though and is able to handle the case of the backup not existing.